### PR TITLE
Removed superfluous line in code cause bug when tag dropdown clicked

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -124,7 +124,6 @@ searchButton.addEventListener("click", displaySearchRecipes);
 //All Recipes Page EVENT LISTENERS --------
 allRecipesMain.addEventListener("click", loadSpecificRecipe);
 allRecipesButton.addEventListener("click", displayAllRecipesPage);
-allRecipeFilterTagOptions.addEventListener("click", displayRecipesOfSameTag);
 searchFilterButton.addEventListener("click", displayRecipesOfSameTag);
 
 //Saved Recipes Page EVENT LISTENERS --------


### PR DESCRIPTION
There was a bug in the code where, if user clicked on the tag dropdown menu to filter by tag, all the HTML thumbnails was cleared out prematurely. The fix was taking out an extra event listener on the tag/dropdown, so now the event listener is onl y on the button.