### PR TITLE
Bugfix recipe thumbnail layout

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -159,6 +159,8 @@ nav {
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 14vw;
+  text-align: center;
 }
 
 .delete-recipe {


### PR DESCRIPTION
# Description
I fixed the thumbnail recipes layout to ensure that there is an equal number of recipe thumbnails per row on all recipe and saved recipe pages. This allows for a smooth user experience when browsing the two pages. 

Fixes # (issue)
Before the bug was fixed, the thumbnails would occasionally be three to a row, and in a row where a recipe had a longer recipe name, there would only be two recipe thumbnails displayed in that row. 

## Type of change
- [x] CSS


- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

To fix this issue I added two CSS declarations to the .single-recipe-text rule:

1.   width: 14vw;  Setting the width made sure that the longer names of recipes did not dictate the width of the entire single recipe thumbnail. It allowed for the single recipe thumbnail widths to be uniform.
2.  text-align: center; Setting the text alignment to center create a pleasing visual look for the UX.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] existing unit tests pass locally with my changes

