### PR TITLE
Bugfix height of background for saved pages.

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -188,7 +188,7 @@ nav {
 /* ~~~ All Recipe/Saved Pages CSS ~~~ */
 .all-recipes-main {
   background-image: url(/src/images/Asset9.png);
-  overflow-y: scroll;
+  height: 100vh;
 }
 
 .page-title {


### PR DESCRIPTION
# Description
I fixed the css styling for the background of the saved recipes page so that the background extends the entire page.

Fixes # (issue)
The background was not extending to the bottom of the page on the saved recipes page.

## Type of change
- [x] CSS

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] existing unit tests pass locally with my changes

