### PR TITLE
Seperate happy and sad paths for recipe repository unit testing.

### DIFF
--- a/test/RecipeRepository-test.js
+++ b/test/RecipeRepository-test.js
@@ -23,15 +23,24 @@ describe('Recipe Repository', () => {
   });
 
   it('Should have a method that creates a filtered list of recipes based on a tag', () => {
-    expect(allRecipes.filterByTag('hello')).to.deep.equal([]);
     expect(allRecipes.filterByTag('snack')).to.deep.equal([recipeRepositorySampleData[0]]);
     expect(allRecipes.filterByTag('lunch')).to.deep.equal(recipeRepositorySampleData);
 
   });
 
+  it('Should have a method that does not create a filtered list of recipes based on a tag that does not exist', () => {
+    expect(allRecipes.filterByTag('cat')).to.deep.equal([]);
+    expect(allRecipes.filterByTag('Dog')).to.deep.equal([]);
+  });
+
   it('Should have a method that creates a filtered list of recipes based on its name', () => {
-    expect(allRecipes.filterByName('Hello')).to.deep.equal([]);
     expect(allRecipes.filterByName('Maple Dijon Apple Cider Grilled Pork Chops')).to.deep.equal([recipeRepositorySampleData[1]]);
+    expect(allRecipes.filterByName('chip')).to.deep.equal([recipeRepositorySampleData[0]]);
+  });
+
+  it('Should have a method that does not create a filtered list of recipes based on a word that does not exist in a recipe name', () => {
+    expect(allRecipes.filterByName('Hello')).to.deep.equal([]);
+    expect(allRecipes.filterByName('thanks')).to.deep.equal([]);
   });
 });
 


### PR DESCRIPTION
# Description

Happy and sad paths for the unit testing of the recipe repository class are broken up to be separate unit tests.

Fixes # (issue)
Sad and happy tests needed to be their own separate tests.
## Type of change

- [x] DataModel

Start at RecipeRepository-test.js. 

- [x] Testing

# How Has This Been Tested?
I ran npm test to make sure that all the tests are passing.

- [x] Test Approved

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

