### PR TITLE
fixed search bar prevent default and changed buttons names for homepage

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -18,8 +18,8 @@
         </button>
         <button class="nav-btns" id="aboutButton">About</button>
         <button class="nav-btns" id="allRecipesButton">All Recipes</button>
-        <button class="nav-btns" id="savedRecipesButton">Your Recipes To Cook</button>
-        <button class="nav-btns" id="userPantryButton">Your Pantry</button>
+        <button class="nav-btns" id="savedRecipesButton">My Recipes</button>
+        <button class="nav-btns" id="userPantryButton">My Pantry</button>
         <form for="searchInput"class="search-bar-wrapper">
           <label for="searchInput" class="hide">site search</label>
           <input

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -259,7 +259,8 @@ function displayARecipe() {
   changeButtonColor();
 }
 
-function displaySearchRecipes() {
+function displaySearchRecipes(event) {
+  event.preventDefault()
   let userInput = searchButtonInput.value;
   let recipesFilteredName;
 


### PR DESCRIPTION
# Description

Prevent default issue that popped up on the search bar
changing button names to " my Recipes" && "my Pantry"

Fixes # (issue)
search bar had a glitch: shorter names help with the screen size reactivity 
## Type of change
- [x] HTML
- [ ] CSS
- [x] DOM
- [ ] DataModel
- [ ] API
- [x] ScriptsJS

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue) 
- [x] This change requires a documentation update

# How Has This Been Tested?
- Page DOM works 


- [x] Test Approved




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

