### PR TITLE
Change tab index of recipe thumbnails and filter so that user filters…

### DIFF
--- a/src/scripts.js
+++ b/src/scripts.js
@@ -267,7 +267,7 @@ function displaySearchRecipes(event) {
   }
 
   if (recipesFilteredName.length !== 0) {
-    displayRecipeThumbnails(recipesFilteredName, "", "", "0");
+    displayRecipeThumbnails(recipesFilteredName, "", "", "1");
   } else {
     allRecipeThumbnailsSection.innerHTML =
       "<h3 class='error-message'> Sorry, no dish with that name or tag can be be found ... order out!</h3>";
@@ -301,8 +301,8 @@ function displayRecipeThumbnails(recipesList, trashbin, trashbinClass, tabIndex)
         `<section class="single-recipe-thumbnail" id = "${recipe.id}"> 
           <img class="single-recipe-img transparent" src=${recipe.image} alt=${recipe.name}> 
             <div class="single-recipe-text"> 
-              <p class="recipe-title-text" tabindex='0'>${recipe.name} </p> 
-              <p class=${trashbinClass} tabindex='0'>${trashbin}</p>
+              <p class="recipe-title-text" tabindex='1'>${recipe.name} </p> 
+              <p class=${trashbinClass} tabindex='1'>${trashbin}</p>
               <p class='meal-ready'>Add ingredients to your pantry to cook this recipe!</p> 
             </div> 
             </section>`);
@@ -311,8 +311,8 @@ function displayRecipeThumbnails(recipesList, trashbin, trashbinClass, tabIndex)
         `<section class="single-recipe-thumbnail" id = "${recipe.id}"> 
           <img class="single-recipe-img" src=${recipe.image} alt=${recipe.name}> 
             <div class="single-recipe-text"> 
-              <p class="recipe-title-text" tabindex='0'>${recipe.name}</p> 
-              <p class=${trashbinClass} tabindex='0'>${trashbin}</p>
+              <p class="recipe-title-text" tabindex='1'>${recipe.name}</p> 
+              <p class=${trashbinClass} tabindex='1'>${trashbin}</p>
               <p class='meal-ready'> Ready to cook! </p>  
             </div> 
         </section>`);
@@ -321,7 +321,7 @@ function displayRecipeThumbnails(recipesList, trashbin, trashbinClass, tabIndex)
       `<section class="single-recipe-thumbnail" id = "${recipe.id}"> 
           <img class="single-recipe-img" src=${recipe.image} alt=${recipe.name}> 
             <div class="single-recipe-text"> 
-              <p class="recipe-title-text" tabindex='0'>${recipe.name}</p> 
+              <p class="recipe-title-text" tabindex='1'>${recipe.name}</p> 
               <p class=${trashbinClass} tabindex=${tabIndex}>${trashbin}</p> 
             </div> 
         </section>`);
@@ -360,7 +360,7 @@ function displayRecipesOfSameTag(event) {
     recipesToTag = allRecipes.filterByTag(inputForTags.value);
     allRecipeFilterTagOptions.selectedIndex = 0;
   }
-  displayRecipeThumbnails(recipesToTag, "", "", "0");
+  displayRecipeThumbnails(recipesToTag, "", "", "1");
 }
 
 //Saved Recipes Page FUNCTIONS --------
@@ -372,7 +372,7 @@ function displaySavedRecipesPage() {
   displayRecipeThumbnails(
     currentUser.recipesToCook.listOfAllRecipes,
     "🗑",
-    "delete-recipe", "0"
+    "delete-recipe", "1"
   );
   createListOfTags(currentUser.recipesToCook.listOfAllRecipes);
 }
@@ -383,7 +383,7 @@ function deleteSavedRecipe(event) {
     displayRecipeThumbnails(
       currentUser.recipesToCook.listOfAllRecipes,
       "🗑",
-      "delete-recipe", "0"
+      "delete-recipe", "1"
     );
   }
 }


### PR DESCRIPTION
# Description

As the user, I should be able to tab to the filter drop-down before tabbing through the single recipe thumbnails on both the my recipe page and the all-recipe page.

Fixes # (issue)
The user has to first tab through all the recipes thumbnails to get to the filter drop-down. To create a smooth UX, I changed the tab index of the single thumbnails to 1 instead of 0. This allows the filter drop-down to be tabbed first.

## Type of change
- [ ] HTML
- [ ] CSS
- [x] DOM
- [ ] DataModel
- [ ] API
- [x] ScriptsJS

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The application was tabbed through in its entirety, making sure that there were no bugs and that the issue was resolved.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

